### PR TITLE
Add breed template and shared styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # dog-breeds
-AI generated simple HTML pages for each AKC-recognized dog breed. Useful for testing structured content generation and templating at scale.
+AI generated simple HTML pages for each AKC-recognized dog breed. Useful for
+testing structured content generation and templating at scale.
 
 ## Index
-
 Open `index.html` to view a dynamically generated list of all AKC-recognized breeds.
+
+## Breed Page Template
+Use `breed-template.html` as the starting point for each individual breed page.
+Copy the file into your `templates/` directory and replace placeholder tokens
+such as `{{BREED_NAME}}`, `{{IMAGE_URL}}`, and `{{BREED_DESCRIPTION}}` with
+actual content. The template references `styles.css` for basic styling so all
+pages remain consistent.

--- a/breed-template.html
+++ b/breed-template.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<!--
+README: Copy this file into the templates/ directory for each breed page and
+replace placeholders like {{BREED_NAME}}, {{IMAGE_URL}}, {{BREED_DESCRIPTION}},
+and other tokens with actual data.
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{BREED_NAME}} - AKC Breed Profile</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>{{BREED_NAME}}</h1>
+  </header>
+  <main>
+    <figure class="breed-image">
+      <img src="{{IMAGE_URL}}" alt="{{BREED_NAME}}">
+      <figcaption>{{BREED_NAME}}</figcaption>
+    </figure>
+    <section class="description">
+      <h2>Description</h2>
+      <p>{{BREED_DESCRIPTION}}</p>
+    </section>
+    <section class="details">
+      <h2>Details</h2>
+      <ul>
+        <li><strong>Group:</strong> {{BREED_GROUP}}</li>
+        <li><strong>Temperament:</strong> {{BREED_TEMPERAMENT}}</li>
+        <li><strong>Height:</strong> {{BREED_HEIGHT}}</li>
+        <li><strong>Weight:</strong> {{BREED_WEIGHT}}</li>
+        <li><strong>Life Expectancy:</strong> {{BREED_LIFE_EXPECTANCY}}</li>
+      </ul>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> AKC Breed Profiles</p>
+  </footer>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,25 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+}
+
+header, footer {
+  background-color: #f4f4f4;
+  text-align: center;
+  padding: 1rem;
+}
+
+main {
+  padding: 1rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.breed-image img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- add reusable `breed-template.html` with placeholders for breed data and semantic layout
- include minimal styling via shared `styles.css`
- document template usage in README

## Testing
- `python -m pytest`
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af40be0b20832397cc89ff312f1d6d